### PR TITLE
Increase value string for ec sensor

### DIFF
--- a/main.c
+++ b/main.c
@@ -69,7 +69,7 @@ typedef struct {
   uint16_t huba_pressure;
   float huba_temperature;
   float ds18b20_temperature;
-  uint8_t atlas_conductivity[4];
+  uint8_t atlas_conductivity[8];
 } packet_t;
 
 // Forward declaration of variables
@@ -119,7 +119,7 @@ void performMeasurements() {
   // Most measurements are timing sensitive, so ignore interrupts
   ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
     // Conductivity data (string holding uS/cm)
-    uint8_t conductivity[4] = {0};
+    uint8_t conductivity[8] = {0};
 
     // Temperature data from DS18B20
     float ds18b20_temperature;
@@ -175,7 +175,7 @@ void performMeasurements() {
         .huba_temperature = huba_temperature,
         .ds18b20_temperature = ds18b20_temperature,
     };
-    for (int ii = 0; ii < 4; ii++) {
+    for (int ii = 0; ii < 8; ii++) {
       packet.atlas_conductivity[ii] = conductivity[ii];
     }
   }

--- a/src/perif/atlas_ezo_ec.c
+++ b/src/perif/atlas_ezo_ec.c
@@ -47,7 +47,7 @@ static void atlas_ezo_ec_sendCommandAndWaitForResponse(char *cmd)
 #define TIMEOUT 100 // Timeout in milliseconds
 
 /// @brief Request value from the Atlas Scientific EZO EC
-/// @param value Pointer to a string that will hold the value
+/// @param value Pointer to a string that will hold the value, size should be fixed to 8 characters
 /// @return 0 if successful, -1 if not
 int atlas_ezo_ec_requestValue(char *value) {
   // Read while there is still data in the buffer to flush the buffer
@@ -62,37 +62,39 @@ int atlas_ezo_ec_requestValue(char *value) {
   // The expected response is x.xx\r*OK\r
   uint8_t response[12];
   uint8_t c;
-  uint8_t ii;
   uint8_t done = 0;
 
-  // Get the start time
-  uint32_t start_time = millis();
+  // Read characters from ec sensor until a carriage return is received or the buffer is full
+  // We don't know how many characters we will receive, but we have a fixed buffer size of 8,
+  // so move the characters to the end of the buffer and pad with zeros
+  uint8_t nofChars = 0;
+  char tmp[8];
+  do {
+    c = uart_read();
 
-  // Read characters until the end of the response is reached
-  while (done == 0) {
-    // Check if the timeout has been reached
-    if (millis() - start_time > TIMEOUT) {
-      return -1; // Return an error code
+    // Store every character except a carriage return
+    if (c != 0x0D) {
+      tmp[nofChars] = c;
+      nofChars++;
     }
+  } while ((c != 0x0D) && (nofChars < 8));
 
-    // start with the value, which is 4 characters and a carriage return
-    for (ii = 0; ii < 4; ii++) {
-      c = uart_read();
-
-      // If the carriage return is reached something went wrong, so start reading the status
-      if (c == 0x0D) {
-        done = 0x01;
-        break;
-      }
-      value[ii] = c;
-    }
-
-    // Read while there is still data in the buffer to flush the buffer
-    while (USART0.STATUS & USART_RXCIF_bm) {
-      uint8_t h = USART0.RXDATAH;
-      uint8_t l = USART0.RXDATAL;
-    }
+  // Fill value with zeros for padding
+  for (int ii = 0; ii < 8; ii++) {
+    value[ii] = 0;
   }
+
+  // Now lets move the received characters to the end of the buffer and pad with zeros
+  for (int ii = nofChars - 1; ((ii < 8) && (ii >= 0)); ii++) {
+    value[ii] = tmp[ii - nofChars];
+  }
+
+  // Read while there is still data in the buffer to flush the buffer
+  while (USART0.STATUS & USART_RXCIF_bm) {
+    uint8_t h = USART0.RXDATAH;
+    uint8_t l = USART0.RXDATAL;
+  }
+
   return 0;
 }
 

--- a/src/perif/atlas_ezo_ec.c
+++ b/src/perif/atlas_ezo_ec.c
@@ -85,8 +85,8 @@ int atlas_ezo_ec_requestValue(char *value) {
   }
 
   // Now lets move the received characters to the end of the buffer and pad with zeros
-  for (int ii = nofChars - 1; ((ii < 8) && (ii >= 0)); ii++) {
-    value[ii] = tmp[ii - nofChars];
+  for (int ii = 0; ii < nofChars; ii++) {
+    value[8 - nofChars + ii] = tmp[ii];
   }
 
   // Read while there is still data in the buffer to flush the buffer


### PR DESCRIPTION
The ec sensor outputs a string between 4 and 6 characters. This fix takes these characters and sets them to the lower end of a fixed 8 character array.
I could not test it as I don't have the sensor.